### PR TITLE
Add defaultPackage = pkgs.nizctl

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
         rec {
           packages = { inherit (pkgs) nizctl niz-qmk-configurator; };
           devShell = pkgs.mkShell { inputsFrom = [ pkgs.nizctl ]; };
+          defaultPackage = pkgs.nizctl;
         }
       ) //
     {


### PR DESCRIPTION
Makes it possible to run this directly:

    nix run github:NickCao/nizctl
